### PR TITLE
feat: Upgrade Spring Boot to 3.5.14. Upgrade related dependencies too

### DIFF
--- a/atp-common-auditing-mongo/pom.xml
+++ b/atp-common-auditing-mongo/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.common.auditing</groupId>
         <artifactId>qubership-atp-common-auditing</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>atp-common-auditing-mongo</artifactId>

--- a/atp-common-auditing-mongo/pom.xml
+++ b/atp-common-auditing-mongo/pom.xml
@@ -95,7 +95,14 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>${maven.compiler.plugin.version}</version>
                         <configuration>
+                            <release>${java.version}</release>
+                            <parameters>true</parameters>
                             <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.projectlombok</groupId>
+                                    <artifactId>lombok</artifactId>
+                                    <version>${lombok.version}</version>
+                                </path>
                                 <path>
                                     <groupId>org.mapstruct</groupId>
                                     <artifactId>mapstruct-processor</artifactId>
@@ -103,16 +110,10 @@
                                 </path>
                                 <path>
                                     <groupId>org.projectlombok</groupId>
-                                    <artifactId>lombok</artifactId>
-                                    <version>${lombok.version}</version>
-                                </path>
-                                <path>
-                                    <groupId>org.projectlombok</groupId>
                                     <artifactId>lombok-mapstruct-binding</artifactId>
                                     <version>0.2.0</version>
                                 </path>
                             </annotationProcessorPaths>
-                            <release>${java.version}</release>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/atp-common-auditing-mongo/pom.xml
+++ b/atp-common-auditing-mongo/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.common.auditing</groupId>
         <artifactId>qubership-atp-common-auditing</artifactId>
-        <version>0.0.12-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>atp-common-auditing-mongo</artifactId>
@@ -32,17 +32,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
         </dependency>
@@ -65,10 +54,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -110,8 +95,6 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>${maven.compiler.plugin.version}</version>
                         <configuration>
-                            <source>${maven.compiler.source}</source>
-                            <target>${maven.compiler.target}</target>
                             <annotationProcessorPaths>
                                 <path>
                                     <groupId>org.mapstruct</groupId>
@@ -129,6 +112,7 @@
                                     <version>0.2.0</version>
                                 </path>
                             </annotationProcessorPaths>
+                            <release>${java.version}</release>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/atp-common-auditing-mongo/pom.xml
+++ b/atp-common-auditing-mongo/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.qubership.atp.common.auditing</groupId>
         <artifactId>qubership-atp-common-auditing</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>atp-common-auditing-mongo</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.13</version>
+        <version>3.5.14</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -21,8 +21,8 @@
         <maven.compiler.target>21</maven.compiler.target>
         <targetJdk>21</targetJdk>
 
-        <spring.boot.version>3.3.13</spring.boot.version>
-        <spring.cloud.version>2023.0.6</spring.cloud.version>
+        <spring.boot.version>3.5.14</spring.boot.version>
+        <spring.cloud.version>2025.0.2</spring.cloud.version>
 
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -34,7 +34,7 @@
         <openclover.version>4.2.0</openclover.version>
         <biz.paluch.logging.version>1.14.1</biz.paluch.logging.version>
         <commons-lang.version>3.20.0</commons-lang.version>
-        <lombok.version>1.18.44</lombok.version>
+        <lombok.version>1.18.46</lombok.version>
         <!-- <tomcat-embed.version>9.0.99</tomcat-embed.version> -->
         <undertow.version>2.3.21.Final</undertow.version>
         <commons-fileupload.version>1.6.0</commons-fileupload.version>
@@ -202,7 +202,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.2</version>
                 <configuration>
                     <argLine>-Dfile.encoding=UTF-8</argLine>
                 </configuration>
@@ -215,7 +214,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.18.0</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -261,11 +259,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.springframework.security</groupId>
-                <artifactId>spring-security-web</artifactId>
-                <version>6.3.10</version>
-            </dependency>
-            <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
                 <version>${spring.cloud.version}</version>
@@ -276,16 +269,6 @@
                 <groupId>biz.paluch.logging</groupId>
                 <artifactId>logstash-gelf</artifactId>
                 <version>${biz.paluch.logging.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>${logback.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-core</artifactId>
-                <version>${logback.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -330,21 +313,6 @@
                 <version>${tomcat-embed.version}</version>
             </dependency> -->
             <dependency>
-                <groupId>io.undertow</groupId>
-                <artifactId>undertow-core</artifactId>
-                <version>${undertow.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.undertow</groupId>
-                <artifactId>undertow-servlet</artifactId>
-                <version>${undertow.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.undertow</groupId>
-                <artifactId>undertow-websockets-jsr</artifactId>
-                <version>${undertow.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
                 <version>${commons-fileupload.version}</version>
@@ -355,56 +323,11 @@
                 <version>${commons-lang.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>${lombok.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.kafka</groupId>
-                <artifactId>spring-kafka</artifactId>
-                <version>3.3.3</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents.client5</groupId>
-                <artifactId>httpclient5</artifactId>
-                <version>${httpclient5.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents.client5</groupId>
-                <artifactId>httpclient5-fluent</artifactId>
-                <version>${httpclient5.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents.core5</groupId>
-                <artifactId>httpcore5</artifactId>
-                <version>${httpcore5.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents.core5</groupId>
-                <artifactId>httpcore5-h2</artifactId>
-                <version>${httpcore5.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.18</version>
+        <version>3.3.13</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
     <groupId>org.qubership.atp.common.auditing</groupId>
     <artifactId>qubership-atp-common-auditing</artifactId>
-    <version>0.0.12-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>atp-common-auditing-mongo</module>
@@ -17,21 +17,21 @@
 
     <properties>
         <java.version>21</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <targetJdk>1.8</targetJdk>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <console.encoding>UTF-8</console.encoding>
-        <spring.boot.version>2.7.18</spring.boot.version>
-        <spring.cloud.version>2021.0.8</spring.cloud.version>
+        <spring.boot.version>3.3.13</spring.boot.version>
+        <spring.cloud.version>2023.0.6</spring.cloud.version>
         <ch.qos.logback.version>1.2.13</ch.qos.logback.version>
         <google.guava.version>32.0.1-jre</google.guava.version>
         <apache.commons>3.12.0</apache.commons>
         <openclover.version>4.2.0</openclover.version>
         <biz.paluch.logging.version>1.14.1</biz.paluch.logging.version>
-        <commons-lang.version>2.6</commons-lang.version>
+        <commons-lang.version>3.20.0</commons-lang.version>
         <lombok.version>1.18.30</lombok.version>
         <tomcat-embed.version>9.0.99</tomcat-embed.version>
         <undertow.version>2.2.39.Final</undertow.version>
@@ -42,7 +42,7 @@
 
         <slf4j.version>1.7.25</slf4j.version>
 
-        <atp.auth.version>1.2.80</atp.auth.version>
+        <atp.auth.version>2.0.2-SNAPSHOT</atp.auth.version>
     </properties>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -257,7 +257,7 @@
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-web</artifactId>
-                <version>5.7.13</version>
+                <version>6.3.10</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
@@ -265,21 +265,6 @@
                 <version>${spring.cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jul-to-slf4j</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>log4j-over-slf4j</artifactId>
-                <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>biz.paluch.logging</groupId>
@@ -300,16 +285,6 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${google.guava.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>${commons-lang.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${apache.commons}</version>
             </dependency>
             <dependency>
                 <groupId>org.openclover</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,28 +19,34 @@
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <mapstruct.version>1.5.5.Final</mapstruct.version>
-        <targetJdk>1.8</targetJdk>
+        <targetJdk>21</targetJdk>
+
+        <spring.boot.version>3.3.13</spring.boot.version>
+        <spring.cloud.version>2023.0.6</spring.cloud.version>
+
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <console.encoding>UTF-8</console.encoding>
-        <spring.boot.version>3.3.13</spring.boot.version>
-        <spring.cloud.version>2023.0.6</spring.cloud.version>
-        <ch.qos.logback.version>1.2.13</ch.qos.logback.version>
+
+        <mapstruct.version>1.6.3</mapstruct.version>
+        <logback.version>1.5.32</logback.version>
         <google.guava.version>32.0.1-jre</google.guava.version>
-        <apache.commons>3.12.0</apache.commons>
         <openclover.version>4.2.0</openclover.version>
         <biz.paluch.logging.version>1.14.1</biz.paluch.logging.version>
         <commons-lang.version>3.20.0</commons-lang.version>
-        <lombok.version>1.18.30</lombok.version>
-        <tomcat-embed.version>9.0.99</tomcat-embed.version>
-        <undertow.version>2.2.39.Final</undertow.version>
+        <lombok.version>1.18.44</lombok.version>
+        <!-- <tomcat-embed.version>9.0.99</tomcat-embed.version> -->
+        <undertow.version>2.3.21.Final</undertow.version>
         <commons-fileupload.version>1.6.0</commons-fileupload.version>
+        <httpclient5.version>5.4.4</httpclient5.version>
+        <httpcore5.version>5.3.4</httpcore5.version>
+        <jackson.version>2.18.6</jackson.version>
+        <mockito.version>5.23.0</mockito.version>
 
-        <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
-        <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
+        <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
+        <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
 
-        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j.version>2.0.17</slf4j.version>
 
         <atp.auth.version>2.0.2-SNAPSHOT</atp.auth.version>
     </properties>
@@ -274,12 +280,12 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>${ch.qos.logback.version}</version>
+                <version>${logback.version}</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>${ch.qos.logback.version}</version>
+                <version>${logback.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -294,7 +300,7 @@
             <dependency>
                 <groupId>org.junit.vintage</groupId>
                 <artifactId>junit-vintage-engine</artifactId>
-                <version>5.9.3</version>
+                <version>5.10.5</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
@@ -308,7 +314,7 @@
                 <artifactId>atp-auth-models</artifactId>
                 <version>${atp.auth.version}</version>
             </dependency>
-            <dependency>
+            <!-- <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-el</artifactId>
                 <version>${tomcat-embed.version}</version>
@@ -322,7 +328,7 @@
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-websocket</artifactId>
                 <version>${tomcat-embed.version}</version>
-            </dependency>
+            </dependency> -->
             <dependency>
                 <groupId>io.undertow</groupId>
                 <artifactId>undertow-core</artifactId>
@@ -342,6 +348,75 @@
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
                 <version>${commons-fileupload.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.kafka</groupId>
+                <artifactId>spring-kafka</artifactId>
+                <version>3.3.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>${httpclient5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5-fluent</artifactId>
+                <version>${httpclient5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>${httpcore5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5-h2</artifactId>
+                <version>${httpcore5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.qubership.atp.common.auditing</groupId>
     <artifactId>qubership-atp-common-auditing</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>atp-common-auditing-mongo</module>
@@ -48,7 +48,7 @@
 
         <slf4j.version>2.0.17</slf4j.version>
 
-        <atp.auth.version>2.0.2-SNAPSHOT</atp.auth.version>
+        <atp.auth.version>2.0.3-SNAPSHOT</atp.auth.version>
     </properties>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
         <biz.paluch.logging.version>1.14.1</biz.paluch.logging.version>
         <commons-lang.version>3.20.0</commons-lang.version>
         <lombok.version>1.18.46</lombok.version>
-        <!-- <tomcat-embed.version>9.0.99</tomcat-embed.version> -->
         <undertow.version>2.3.21.Final</undertow.version>
         <commons-fileupload.version>1.6.0</commons-fileupload.version>
         <httpclient5.version>5.4.4</httpclient5.version>
@@ -283,7 +282,7 @@
             <dependency>
                 <groupId>org.junit.vintage</groupId>
                 <artifactId>junit-vintage-engine</artifactId>
-                <version>5.10.5</version>
+                <version>5.12.2</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
@@ -297,21 +296,6 @@
                 <artifactId>atp-auth-models</artifactId>
                 <version>${atp.auth.version}</version>
             </dependency>
-            <!-- <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-el</artifactId>
-                <version>${tomcat-embed.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>${tomcat-embed.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-websocket</artifactId>
-                <version>${tomcat-embed.version}</version>
-            </dependency> -->
             <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.qubership.atp.common.auditing</groupId>
     <artifactId>qubership-atp-common-auditing</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>atp-common-auditing-mongo</module>
@@ -43,11 +43,11 @@
         <mockito.version>5.23.0</mockito.version>
 
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
-        <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
 
         <slf4j.version>2.0.17</slf4j.version>
 
-        <atp.auth.version>2.0.3-SNAPSHOT</atp.auth.version>
+        <atp.auth.version>2.0.0</atp.auth.version>
     </properties>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -201,6 +201,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <argLine>-Dfile.encoding=UTF-8</argLine>
                 </configuration>
@@ -324,6 +325,23 @@
                 <artifactId>mockito-junit-jupiter</artifactId>
                 <version>${mockito.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.84</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-test</artifactId>
+                <version>${spring.boot.version}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.vaadin.external.google</groupId>
+                        <artifactId>android-json</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Due to Security reasons, atp-common-auditing library is upgraded to Spring Boot 3.5.14.
All related dependencies (including plugins) are upgraded too.

<!-- start messages -->
### Commit messages:
[kagw95](https://github.com/Netcracker/qubership-testing-platform-common-auditing-library/commit/060a2d39d77535827114872e270d63181b087d4a) feat: Spring Boot upgrade to 3.3.13: initial changes by OpenRewrite plugin. Project version is changed to 1.0.0-SNAPSHOT. Bump atp-auth to 2.0.2-SNAPSHOT.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-common-auditing-library/commit/3d89fdd6c2da62406aad53e569376a1b683083a4) fix(deps): Bump mapstruct to 1.6.3, logback to 1.5.32, lombok to 1.18.44, undertow to 2.3.21.Final, httpclient5 to 5.4.4, httpcore5 to 5.3.4, jackson to 2.18.6, mockito to 5.23.0, slf4j to 2.0.17, spring-kafka to 3.3.3.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-common-auditing-library/commit/d67cb1b8c4a5a2095cda401d89dd239f804bf34c) feat: Spring Boot upgrade to 3.5.14: Dependencies changes by OpenRewrite plugin.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-common-auditing-library/commit/43ca616ff5bd948d1d75c5709defffd0b46a82d2) feat: Spring Boot upgrade to 3.5.14: Bump atp-auth to 2.0.3-SNAPSHOT. Set project version to 1.0.1-SNAPSHOT.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-common-auditing-library/commit/6df286fcbef0530dd1177df38143a0b1ca6aaeef) fix(deps): Bump Jupiter to 5.12.2, remove tomcat deps commented earlier.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-common-auditing-library/commit/ab1fca9262604fe33f26d5b96555f1f3f22ddacd) Merge branch 'main' into feature/springboot-upgrade-3-5-14
[kagw95](https://github.com/Netcracker/qubership-testing-platform-common-auditing-library/commit/a34b778bcc1161d99eca9ffc07fa96dbbfd9820d) fix(deps): Unify dependencies: Bump atp-auth to 2.0.0, bouncycastle to 1.84, maven-surefire-plugin to 3.5.5. Exclude com.vaadin.external.google:android-json from spring-boot-starter-test. Project version is set to 1.0.0-SNAPSHOT.
<!-- end messages -->
